### PR TITLE
No Bug - Added fastlane toolchain for iOS build automation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ npm-debug.log
 
 # Never commit a keystore
 *.keystore
+
+# Fastlane
+ios/fastlane/report.xml

--- a/ios/fastlane/Appfile
+++ b/ios/fastlane/Appfile
@@ -1,0 +1,6 @@
+app_identifier "org.mozilla.ios.Magnet" # The bundle identifier of your app
+
+team_id "43AQ936H96"  # Developer Portal Team ID
+
+# you can even provide different app identifiers, Apple IDs and team names per lane:
+# More information: https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Appfile.md

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -1,0 +1,59 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# Customise this file, documentation can be found here:
+# https://github.com/fastlane/fastlane/tree/master/docs
+# All available actions: https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Actions.md
+# can also be listed using the `fastlane actions` command
+
+# Change the syntax highlighting to Ruby
+# All lines starting with a # are ignored when running `fastlane`
+
+# If you want to automatically update fastlane if a new version is available:
+# update_fastlane
+
+# This is the minimum version number required.
+# Update this, if you use features of a newer version
+fastlane_version "1.80.0"
+
+default_platform :ios
+
+platform :ios do
+  before_all do
+    # ENV["SLACK_URL"] = "https://hooks.slack.com/services/..."
+  end
+
+  desc "Submit a new Beta Build to Apple TestFlight"
+  desc "This will also make sure the profile is up to date"
+  lane :beta do
+    # Grab the version number and the last build number on TestFlight so we can auto increment
+    version = get_version_number(xcodeproj: "magnet.xcodeproj")
+    build_number = latest_testflight_build_number(
+      version: version,
+      initial_build_number: 0
+    ) + 1
+
+    increment_build_number(
+      build_number: build_number,
+      xcodeproj: 'magnet.xcodeproj'
+    )
+
+    # Compile and build .xcarchive
+    gym(
+      scheme: "magnet",
+      use_legacy_build_api: true  
+    ) 
+
+    # Upload the build to TestFlight
+    pilot(
+      skip_submission: true
+    )
+  end
+
+  after_all do |lane|
+  end
+
+  error do |lane, exception|
+  end
+end

--- a/ios/fastlane/README.md
+++ b/ios/fastlane/README.md
@@ -1,0 +1,21 @@
+fastlane documentation
+================
+# Installation
+```
+sudo gem install fastlane
+```
+# Available Actions
+## iOS
+### ios beta
+```
+fastlane ios beta
+```
+Submit a new Beta Build to Apple TestFlight
+
+This will also make sure the profile is up to date
+
+----
+
+This README.md is auto-generated and will be re-generated every time to run [fastlane](https://fastlane.tools).
+More information about fastlane can be found on [https://fastlane.tools](https://fastlane.tools).
+The documentation of fastlane can be found on [GitHub](https://github.com/fastlane/fastlane/tree/master/fastlane).


### PR DESCRIPTION
Hey!

I'm on the Firefox for iOS team and heard you were looking for some ways to package up the application for distribution for testers. For Firefox, we use Fastlane (https://github.com/fastlane) for our build automation. I believe it also supports Android if you're looking to automation that process down the road as well. I've setup a basic fastlane script that will build/package/upload the Magnet app to TestFlight so you can release the build to either internal/external users. 

If you're looking for more information about the build process for iOS feel free to reach out. For reference, here is the repo where we have our build automation tooling setup [1]

[1] https://github.com/mozilla/firefox-ios-build-tools
