### PR TITLE
(#59) If RELEASE_KEY_STORE_FILE is not set, don't try and configure APK signing

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -91,12 +91,14 @@ android {
         }
     }
 
-    signingConfigs {
-        release {
-            storeFile file(RELEASE_STORE_FILE)
-            storePassword RELEASE_STORE_PASSWORD
-            keyAlias RELEASE_KEY_ALIAS
-            keyPassword RELEASE_KEY_PASSWORD
+    if (RELEASE_STORE_FILE) {
+        signingConfigs {
+            release {
+                storeFile file(RELEASE_STORE_FILE)
+                storePassword RELEASE_STORE_PASSWORD
+                keyAlias RELEASE_KEY_ALIAS
+                keyPassword RELEASE_KEY_PASSWORD
+            }
         }
     }
 
@@ -112,7 +114,10 @@ android {
         release {
             minifyEnabled enableProguardInReleaseBuilds
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
-            signingConfig signingConfigs.release
+
+            if (signingConfigs.contains(release)) {
+                signingConfig signingConfigs.release
+            }
         }
     }
     // applicationVariants are e.g. debug, release


### PR DESCRIPTION
Fixes #59.  Ideally gradle would ignore release config for debug builds..

r? @wilsonpage  
