### PR TITLE
Use org.mozilla.magnet namespace

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -81,7 +81,7 @@ android {
     buildToolsVersion "23.0.1"
 
     defaultConfig {
-        applicationId "com.magnet"
+        applicationId "org.mozilla.magnet"
         minSdkVersion 16
         targetSdkVersion 22
         versionCode 1

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.magnet">
+    package="org.mozilla.magnet">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.BLUETOOTH" />
@@ -11,7 +11,7 @@
       android:icon="@mipmap/ic_launcher"
       android:theme="@style/AppTheme">
       <activity
-        android:name="com.magnet.MainActivity"
+        android:name="org.mozilla.magnet.MainActivity"
         android:label="@string/app_name"
         android:configChanges="keyboard|keyboardHidden|orientation|screenSize">
         <intent-filter>

--- a/android/app/src/main/java/org/mozilla/magnet/MainActivity.java
+++ b/android/app/src/main/java/org/mozilla/magnet/MainActivity.java
@@ -1,4 +1,4 @@
-package com.magnet;
+package org.mozilla.magnet;
 
 import com.facebook.react.ReactActivity;
 import com.facebook.react.ReactPackage;

--- a/android/app/src/main/java/org/mozilla/magnet/MyAppPackage.java
+++ b/android/app/src/main/java/org/mozilla/magnet/MyAppPackage.java
@@ -1,4 +1,4 @@
-package com.magnet;
+package org.mozilla.magnet;
 
 import com.facebook.react.ReactPackage;
 import com.facebook.react.bridge.JavaScriptModule;

--- a/android/app/src/main/java/org/mozilla/magnet/ScannerBle.java
+++ b/android/app/src/main/java/org/mozilla/magnet/ScannerBle.java
@@ -1,4 +1,4 @@
-package com.magnet;
+package org.mozilla.magnet;
 
 import android.annotation.TargetApi;
 import android.bluetooth.BluetoothAdapter;

--- a/android/app/src/main/java/org/mozilla/magnet/ScannerNetwork.java
+++ b/android/app/src/main/java/org/mozilla/magnet/ScannerNetwork.java
@@ -1,4 +1,4 @@
-package com.magnet;
+package org.mozilla.magnet;
 
 import android.content.Context;
 import android.net.nsd.NsdManager;


### PR DESCRIPTION
Chosen for consistency with org.mozilla.gecko ¯_(ツ)_/¯.  And we shouldn't use 'com.magnet', as someone else has almost certainly got that namespace and package names should be unique.

I think it's OK to not include 'android' in the namespace as we have done for iOS.

https://developer.android.com/guide/topics/manifest/manifest-element.html#package 

Note:

> Once you publish your application, **you cannot change the package name**. The package name defines your application's identity, so if you change it, then it is considered to be a different application and users of the previous version cannot update to the new version.

r? @wilsonpage 
