### PR TITLE
Don't remove all the tiles on refresh

### DIFF
--- a/lib/scanner/index.js
+++ b/lib/scanner/index.js
@@ -135,28 +135,53 @@ class Scanner {
    * @public
    */
   clear() {
-    this.items = {};
+    const thirtySeconds = 1000 * 30;
+    const now = Date.now();
+
+    const keysToRemove = Object.keys(this.items).filter((key) => {
+      return (now - this.items[key].lastSeen) > thirtySeconds;
+    });
+
+    // Only update the view if there is something to change
+    let keysDeleted = false;
+    keysToRemove.forEach((key) => {
+      keysDeleted = true;
+      delete this.items[key];
+    });
+
+    if (keysDeleted) {
+      this.notify();
+    }
   }
 
   /**
    * When a URL is found we fetch its
-   * associated metadata then call
-   * the given callback.
+   * associated metadata then notify
+   * the listener.
    *
    * @param  {String} url
    * @private
    */
   onUrlFound(url) {
-    if (this.items[url]) return;
-    debug('url found', url);
-    this.items[url] = url;
+    if (this.items[url]) {
+      this.items[url].lastSeen = Date.now();
+      return;
+    }
+
+    this.items[url] = {
+      url: url,
+      lastSeen: Date.now(),
+    };
+
     debug('fetching metadata ...');
     metadata(url)
-      .then(data => {
+      .then((data) => {
         if (!data) return debug('metadata fetch failed', url);
+
         debug('got metadata: %s', url, data);
         data.id = ++counter;
-        this.callback(data);
+        this.items[url].data = data;
+        this.notify();
       })
 
       .catch(err => {
@@ -166,6 +191,17 @@ class Scanner {
           this.netErrorListener(err);
         }
       });
+  }
+
+  /**
+   * Notify the listener (`callback`) of
+   * a change in state.
+   *
+   * @private
+   */
+  notify() {
+    let items = Object.keys(this.items).map((key) => this.items[key].data);
+    this.callback(items);
   }
 }
 

--- a/lib/scanner/index.js
+++ b/lib/scanner/index.js
@@ -11,6 +11,7 @@ var BleScanner = require('./ble');
 
 const SCAN_INTERVAL = 30000; // 30secs
 const SCAN_LENGTH = 10000; // 10secs
+const ITEM_EXPIRES = 30000; // 30secs
 var counter = 0;
 
 class Scanner {
@@ -135,19 +136,16 @@ class Scanner {
    * @public
    */
   clear() {
-    const thirtySeconds = 1000 * 30;
     const now = Date.now();
 
-    const keysToRemove = Object.keys(this.items).filter((key) => {
-      return (now - this.items[key].lastSeen) > thirtySeconds;
-    });
-
-    // Only update the view if there is something to change
-    let keysDeleted = false;
-    keysToRemove.forEach((key) => {
-      keysDeleted = true;
-      delete this.items[key];
-    });
+    const keysDeleted = Object.keys(this.items).reduce((keysDeleted, key) => {
+      if ((now - this.items[key].lastSeen) > ITEM_EXPIRES) {
+        delete this.items[key];
+        return true;
+      } else {
+        return keysDeleted;
+      }
+    }, false);
 
     if (keysDeleted) {
       this.notify();

--- a/lib/views/list.js
+++ b/lib/views/list.js
@@ -31,7 +31,7 @@ class List extends Component {
 
     this.onItemLongPress = this.onItemLongPress.bind(this);
     this.scanner = new Scanner({
-      callback: this.onItemFound.bind(this),
+      callback: this.onUpdate.bind(this),
       netErrorListener: () => {
         Alert.alert('Network error', 'Please check your internet connection');
       }
@@ -44,15 +44,9 @@ class List extends Component {
     setTimeout(() => this.scanner.start(), 1000);
   }
 
-  onItemFound(item) {
-    this.addItem(item);
-  }
-
-  addItem(item) {
-    debug('add item', item);
-    this.state.items.unshift(item);
+  onUpdate(items) {
     LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
-    this.setState({ items: this.state.items });
+    this.setState({ items: items });
   }
 
   refresh() {
@@ -60,11 +54,11 @@ class List extends Component {
     debug('refreshing ...');
 
     this.setState({
-      refreshing: true,
-      items: []
+      refreshing: true
     });
 
     this.scanner.clear();
+
     this.scanner.advance().then(() => {
       this.setState({ refreshing: false });
       debug('refreshed');


### PR DESCRIPTION
Instead update the existing list and evict URLs we haven't seen for a while.  This means we don't need to re-render the whole list on refresh. :)

r? @wilsonpage 
