### PR TITLE
Bump the minimum API version. 

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -86,7 +86,7 @@ android {
 
     defaultConfig {
         applicationId "org.mozilla.magnet"
-        minSdkVersion 16
+        minSdkVersion 18
         targetSdkVersion 22
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
 We're using APIs that require at least 18. If this were to be run on an older device, it would cause a runtime crash.

r? @wilsonpage 
