### PR TITLE
Make the app_name parameter in metrics fixed, so it's the same for io…

### DIFF
--- a/lib/utils/metrics.js
+++ b/lib/utils/metrics.js
@@ -159,7 +159,7 @@ function MagnetMetrics(storage) {
       os: DeviceInfo.getSystemName(),
       os_version: DeviceInfo.getSystemVersion(),
       device: DeviceInfo.getDeviceName(),
-      app_name: DeviceInfo.getBundleId(),
+      app_name: 'org.mozilla.magnet',
       app_version: DeviceInfo.getReadableVersion(),
       app_build_id: DeviceInfo.getBuildNumber(),
       app_platform: manufacturer


### PR DESCRIPTION
…s and android.

Closes #172 

@wilsonpage r?
