### PR TITLE
Deep linking to item view when notification is clicked

### DIFF
--- a/ios/NotificationsHelperIOS10.swift
+++ b/ios/NotificationsHelperIOS10.swift
@@ -85,6 +85,11 @@ class NotificationsHelperIOS10: NSObject, UNUserNotificationCenterDelegate {
       debugPrint("Launching web page \(response.notification.request.identifier)")
       let url = NSURL(string: response.notification.request.identifier)
       UIApplication.sharedApplication().openURL(url!, options: [:], completionHandler: nil)
+    } else {
+      // We were clicked but not the visit (go to browser) action
+      // so we navigate to the deep link inside the app
+      let url = NSURL(string: "mozilla-magnet:item?url=\(response.notification.request.identifier)")
+      UIApplication.sharedApplication().openURL(url!, options: [:], completionHandler: nil)
     }
   }
   

--- a/ios/NotificationsHelperIOS10.swift
+++ b/ios/NotificationsHelperIOS10.swift
@@ -88,7 +88,7 @@ class NotificationsHelperIOS10: NSObject, UNUserNotificationCenterDelegate {
     } else {
       // We were clicked but not the visit (go to browser) action
       // so we navigate to the deep link inside the app
-      let url = NSURL(string: "mozilla-magnet:item?url=\(response.notification.request.identifier)")
+      let url = NSURL(string: "mozilla-magnet://item?url=\(response.notification.request.identifier)")
       UIApplication.sharedApplication().openURL(url!, options: [:], completionHandler: nil)
     }
   }


### PR DESCRIPTION
@wilsonpage r?

Before we were just handling the click on the custom actions, but not the normal notification.

This will end fixing #189